### PR TITLE
chore: GitHub issue templates (task + bug)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,10 @@
+---
+name: Bug report
+about: Report unexpected behavior or a defect
+title: "[Bug] "
+labels: bug
+---
+
 ## Expected Behavior
 
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,37 @@
+---
+name: Task
+about: Planned work item (feature slice, refactor, chore, spike)
+title: "[Task] "
+labels: task
+---
+
+## Summary
+
+
+## Context / Why
+
+
+## Scope
+
+**In scope**
+
+- 
+
+**Out of scope**
+
+- 
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+
+## Dependencies
+
+- Blocked by:
+- Blocks:
+
+
+## Notes / references
+
+- Links, design, PRD, related issues:


### PR DESCRIPTION
# Fixes #

_No linked issue._

## Purpose

Standardize GitHub issue templates under `.github/ISSUE_TEMPLATE/` and add a **task**-oriented template next to the bug report.

## Changes

- Add `ISSUE_TEMPLATE/task.md`, `bug_report.md` (bug flow with YAML frontmatter), and `config.yml` with `blank_issues_enabled: true`.
- Remove legacy `.github/issue_template.md` so the official template folder is the single source of truth.

## How to Test

1. Open **Issues** → **New issue** and confirm the chooser lists **Bug report** and **Task**.
2. Open each template and check default title prefixes and labels (`bug` / `task` — create labels in the repo if missing).

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have commented my code, particularly in hard-to-understand areas _(N/A — Markdown templates only)_
