### PR TITLE
fix: sanitize validation errors to hide sensitive input

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,6 @@ from src.auth import routes as auth_routes
 from src.config import settings
 
 
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     async with engine.begin() as conn:
@@ -41,13 +40,13 @@ if settings.DEBUG:
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
-    
+
     errors = exc.errors()
     for error in errors:
         if "input" in error:
             del error["input"]
-            
+
     return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         content={"detail": errors},
     )


### PR DESCRIPTION
## Purpose
Prevent exposure of sensitive data (like plain-text passwords) in 422 validation error responses.

## Changes
- Added a global `RequestValidationError` handler in `main.py`.
- Stripped the `input` field from Pydantic error details before returning the response.

## How to Test
1. Attempt to signup with a short password (e.g., "123").
2. Check the JSON response: the `detail` list should contain the error message but NOT the `input` key with the actual password.
## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined API validation error payloads by removing internal/input fields from error details, making responses clearer and easier to act on.
  * Standardized validation error responses to consistently return HTTP 422 with a unified error structure for more predictable client behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->