### PR TITLE
Issue 49 budget creation invalid + expense creation invalid

### DIFF
--- a/src/domain/budget/service.py
+++ b/src/domain/budget/service.py
@@ -30,7 +30,7 @@ class BudgetService(BaseService[Budget, BudgetCreateSchema, BudgetSchema, Budget
         """
         if data.category_id is not None:
             category_service = CategoryService(self.db)
-            category = category_service.get_by_id(data.category_id, user_id)
+            category = await category_service.get_by_id(data.category_id, user_id)
 
         new_budget = Budget(**data.model_dump(), user_id=user_id)
 

--- a/src/domain/expense/service.py
+++ b/src/domain/expense/service.py
@@ -15,7 +15,7 @@ class ExpenseService(BaseService[Expense, ExpenseCreateSchema, ExpenseSchema, Ex
 
         if data.category_id is not None:
             category_service = CategoryService(self.db)
-            category = category_service.get_by_id(data.category_id, user_id)
+            category = await category_service.get_by_id(data.category_id, user_id)
 
         expense = Expense(**data.model_dump(exclude={"user_id"}))
         expense.user_id = user_id


### PR DESCRIPTION
# Fixes #
Invalid Category_ID returning 500 for expense and budget creation
## Purpose
## Changes
Updated Expense Service and Budget Service to get category_id using CategoryService to ensure proper error is displayed and workflow is correct

## How to Test
1. 
2. 
## ✅ Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added optional category validation when creating budgets and expenses: if a category is provided it is now validated before the item is created, reducing chances of creating records with invalid category references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->