### PR TITLE
Fix: src/main.py -> validation_exception_handler : Removed ctx

### DIFF
--- a/src/auth/tests/test_auth_view.py
+++ b/src/auth/tests/test_auth_view.py
@@ -13,8 +13,80 @@ class TestAuthView:
         assert respose.status_code == 201
 
     @pytest.mark.asyncio
-    async def test_signup_with_invalid_data(self, async_client, valid_user):
+    async def test_signup_empty_email(self, async_client, valid_user):
         valid_user.email = ""
+        respose = await async_client.post(
+            "/auth/signup",
+            data=valid_user.model_dump_json(),
+        )
+        assert respose.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_signup_empty_username(self, async_client, valid_user):
+        valid_user.username = ""
+        respose = await async_client.post(
+            "/auth/signup",
+            data=valid_user.model_dump_json(),
+        )
+        assert respose.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_signup_empty_password(self, async_client, valid_user):
+        valid_user.password = ""
+        respose = await async_client.post(
+            "/auth/signup",
+            data=valid_user.model_dump_json(),
+        )
+        assert respose.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_signup_short_password(self, async_client, valid_user):
+        valid_user.password = "123"
+        respose = await async_client.post(
+            "/auth/signup",
+            data=valid_user.model_dump_json(),
+        )
+        assert respose.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_signup_password_unsafe(self, async_client, valid_user):
+        # MISSING SPECIAL CHARACTER
+        valid_user.password = "ExpenseaApp123"  # missing special character
+        respose = await async_client.post(
+            "/auth/signup",
+            data=valid_user.model_dump_json(),
+        )
+        assert respose.status_code == 422
+
+        # MISSING UPPERCASE
+        valid_user.password = "expenseapp123#"  # missing special character
+        respose = await async_client.post(
+            "/auth/signup",
+            data=valid_user.model_dump_json(),
+        )
+        assert respose.status_code == 422
+
+        # MISSING LOWERCASE
+        valid_user.password = "EXPENSEAPP123#"
+        respose = await async_client.post(
+            "/auth/signup",
+            data=valid_user.model_dump_json(),
+        )
+        assert respose.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_signup_with_invalid_username(self, async_client, valid_user):
+
+        # USERNAME WITH SPACES NOT ALLOWED
+        valid_user.username = "username with spaces"
+        respose = await async_client.post(
+            "/auth/signup",
+            data=valid_user.model_dump_json(),
+        )
+        assert respose.status_code == 422
+
+        # USERNAME WITH SPECIAL CHARACTERS NOT ALLOWED
+        valid_user.username = "CharNotValid!@#"
         respose = await async_client.post(
             "/auth/signup",
             data=valid_user.model_dump_json(),
@@ -55,7 +127,7 @@ class TestAuthView:
     async def test_get_current_user(self, user, async_client, valid_user):
         """
         Verify that an authenticated user can retrieve their own profile from /auth/me.
-        
+
         Logs in using `valid_user`, extracts the access token from the login response, requests `/auth/me` with the Bearer token, and asserts the endpoint returns HTTP 200 and a response parsable as `UserResponseSchema`.
         """
         response = await async_client.post(
@@ -78,10 +150,9 @@ class TestAuthView:
     async def test_get_current_user_unauthenticated(
         self, user, async_client, valid_user
     ):
-
         """
         Verifies that a request to `/auth/me` with an invalid Bearer token is rejected.
-        
+
         Sends a GET request to `/auth/me` using an invalid Authorization header and asserts the response status code is 401.
         """
         user_response = await async_client.get(

--- a/src/main.py
+++ b/src/main.py
@@ -88,7 +88,8 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         for error in errors:
             if "input" in error:
                 del error["input"]
-
+            if "ctx" in error:
+                del error["ctx"]
         return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,  # or HTTP_422_UNPROCESSABLE_ENTITY
             content={"detail": errors},


### PR DESCRIPTION
closes #50 

# Fixes #
Fix: src/main.py -> validation_exception_handler : Removed ctx

## Purpose
Correct Error Handling for RequestValidationError
## Changes
src/main.py -> validation_exception_handler : Removed ctx

## How to Test
1. 
2. 
## ✅ Checklist
- [✅ ] My code follows the style guidelines of this project
- [ ✅] I have performed a self-review of my own code
- [✅ ] I have commented my code, particularly in hard-to-understand areas
- [ ✅] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Acceptance criteria
- [x] `POST /auth/signup` with `"username": "new as asd"` returns HTTP 422 with a JSON body — no ASGI crash
- [x] Response `detail` array contains `type`, `loc` and `msg` for each error
- [x] Fields `input` and `ctx` are not present in any error dict in the response
- [x] The fallback `except` branch is NOT triggered for normal validation errors
- [x] Valid payloads continue to return HTTP 200
- [ ] New tests added covering at least: invalid payload with custom field validator, valid payload, and multiple simultaneous validation errors
- [x] `POST /auth/signup` with a password longer than 8 characters but failing pattern validation
      returns HTTP 422 with a JSON body — no ASGI crash

* **Bug Fixes**
  * Improved validation error responses to provide cleaner and more focused error messages by removing unnecessary context information from error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->