### PR TITLE
feat: add OAuth2 login endpoint and service function for handling OAuth2 login

### DIFF
--- a/src/auth/oauth2.py
+++ b/src/auth/oauth2.py
@@ -12,13 +12,13 @@ from src.config import settings
 SECRET_KEY = settings.SECRET_KEY
 ALGORITHM = settings.ALGORITHM
 ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
-REFRESH_TOKEN_EXPIRE_MINUTES = settings.REFRESH_TOKEN_EXPIRE_MINUTES  #new
+REFRESH_TOKEN_EXPIRE_MINUTES = settings.REFRESH_TOKEN_EXPIRE_MINUTES  # new
 
 # Hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 # OAuth2
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/oauth2/login")
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -91,6 +91,6 @@ async def get_current_admin(current_user: User = Depends(get_current_user)):
     if current_user.role != "admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not enough permissions. Admin role required."
+            detail="Not enough permissions. Admin role required.",
         )
     return current_user

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
-
+from fastapi.security import OAuth2PasswordRequestForm
 from src.db.database import get_db
 from src.auth import schemas, service
 from src.auth.oauth2 import get_current_user
@@ -25,8 +25,26 @@ async def login(
     user_credentials: schemas.LoginSchema,
     db: AsyncSession = Depends(get_db),
 ):
-    #update
+    # update
     tokens = await service.login_user_service(user_credentials, db)
+    return tokens
+
+
+@router.post("/oauth2/login", response_model=schemas.TokenSchema)
+async def login_oauth(
+    user_credentials: OAuth2PasswordRequestForm = Depends(),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+
+    Since the problems faced by front-end with login requiring formData for login flow
+    the payload for login was replaced by custom LoginSchema, that solves the problem for login with json payload.
+    However, for OAUth2 login flow, the formData is still required, so for the OAuth2 login flow, the endpoint is still using OAuth2PasswordRequestForm
+    but its now has a seperated route -> /auth/oauth2/login
+
+    """
+
+    tokens = await service.login_oauth(user_credentials, db)
     return tokens
 
 
@@ -39,11 +57,10 @@ async def get_me(user: schemas.UserResponseSchema = Depends(get_current_user)):
 # new refresh token router
 @router.post("/refresh", response_model=schemas.TokenSchema)
 async def refresh_token(
-    token_data: schemas.RefreshRequestSchema,
-    db: AsyncSession = Depends(get_db)
+    token_data: schemas.RefreshRequestSchema, db: AsyncSession = Depends(get_db)
 ):
     """
-    Endpoint used by the frontend to obtain a new access token 
+    Endpoint used by the frontend to obtain a new access token
     when the previous one expires, using a valid refresh token.
     """
     tokens = await service.refresh_token_service(token_data.refresh_token, db)

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -1,4 +1,5 @@
 from fastapi import HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from jose import jwt, JWTError
@@ -37,6 +38,32 @@ async def create_user_service(user_credentials: UserCreateSchema, db: AsyncSessi
 async def login_user_service(user_credentials: LoginSchema, db: AsyncSession):
     # user
     result = await db.execute(select(User).filter(User.email == user_credentials.email))
+    user = result.scalars().first()
+
+    # credentials
+    if not user or not oauth2.verify_password(
+        user_credentials.password, user.password_hash
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid credentials"
+        )
+
+    # 2 token
+    access_token = oauth2.create_access_token(data={"user_id": str(user.uid)})
+    refresh_token = oauth2.create_refresh_token(data={"user_id": str(user.uid)})
+
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+    }
+
+
+async def login_oauth(user_credentials: OAuth2PasswordRequestForm, db: AsyncSession):
+    # user
+    result = await db.execute(
+        select(User).filter(User.email == user_credentials.username)
+    )
     user = result.scalars().first()
 
     # credentials


### PR DESCRIPTION

# Fixes #
#58 


## Purpose
## Changes
- Added a new route for oauth lofin -> /auth/oauth2/login
- added new method for login with oauth route 

## How to Test
1. Try to loin via `/docs` endpoint -> that will use new /auth/oauth2/login
2. Try to login via `json data` using postman or front-end -> That will use old /auth/login


## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth2 password grant authentication flow with a dedicated login endpoint for secure token-based authentication.

* **Updates**
  * Updated OAuth2 token endpoint path for improved API routing structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->