### PR TITLE
feat: add query parameters for expense filtering (Issue #62)

### DIFF
--- a/src/domain/expense/routes.py
+++ b/src/domain/expense/routes.py
@@ -1,5 +1,8 @@
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Optional
+from datetime import date
+from decimal import Decimal
 
 from src.auth.oauth2 import get_current_user
 from src.db.database import get_db
@@ -28,9 +31,21 @@ async def create_expense(
 async def list_expenses(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    date: Optional[date] = None,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    min_value: Optional[Decimal] = None,
+    max_value: Optional[Decimal] = None,
 ):
     service = ExpenseService(db)
-    return await service.get_all(current_user.uid)
+    return await service.get_all(
+        user_id=current_user.uid,
+        date_filter=date,
+        start_date=start_date,
+        end_date=end_date,
+        min_value=min_value,
+        max_value=max_value
+    )
 
 
 @router.get("/{expense_id}", response_model=ExpenseSchema)

--- a/src/domain/expense/routes.py
+++ b/src/domain/expense/routes.py
@@ -1,8 +1,8 @@
-from fastapi import APIRouter, Depends, status
-from sqlalchemy.ext.asyncio import AsyncSession
-from typing import Optional
 from datetime import date
 from decimal import Decimal
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.auth.oauth2 import get_current_user
 from src.db.database import get_db
@@ -31,11 +31,11 @@ async def create_expense(
 async def list_expenses(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
-    date: Optional[date] = None,
-    start_date: Optional[date] = None,
-    end_date: Optional[date] = None,
-    min_value: Optional[Decimal] = None,
-    max_value: Optional[Decimal] = None,
+    date: date | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    min_value: Decimal | None = None,
+    max_value: Decimal | None = None,
 ):
     service = ExpenseService(db)
     return await service.get_all(
@@ -44,7 +44,7 @@ async def list_expenses(
         start_date=start_date,
         end_date=end_date,
         min_value=min_value,
-        max_value=max_value
+        max_value=max_value,
     )
 
 

--- a/src/domain/expense/service.py
+++ b/src/domain/expense/service.py
@@ -1,4 +1,8 @@
 from src.models import Expense
+from datetime import date
+from decimal import Decimal
+from typing import Any, Optional
+from sqlalchemy import select, func
 from src.exceptions import EntityNotFoundException, DatabaseException
 from src.common.base_service import BaseService
 from src.domain.expense.schemas import (
@@ -111,7 +115,31 @@ class ExpenseService(
 
         return expense
 
-    async def get_all(self, user_id: UUID) -> list[Expense]:
+    async def get_all(
+        self, 
+        user_id: UUID,
+        date_filter: Optional[date] = None,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+        min_value: Optional[Decimal] = None,
+        max_value: Optional[Decimal] = None
+    ) -> list[Expense]:
+
         statement = select(Expense).where(Expense.user_id == user_id)
+        
+        if date_filter is not None:
+            statement = statement.where(func.date(Expense.transaction_date) == date_filter)
+            
+        # Filtri per range di date
+        if start_date is not None:
+            statement = statement.where(func.date(Expense.transaction_date) >= start_date)
+        if end_date is not None:
+            statement = statement.where(func.date(Expense.transaction_date) <= end_date)
+            
+        if min_value is not None:
+            statement = statement.where(Expense.amount >= min_value)
+        if max_value is not None:
+            statement = statement.where(Expense.amount <= max_value)
+
         result = await self.db.execute(statement)
-        return result.scalars().all()
+        return list(result.scalars().all())

--- a/src/domain/expense/service.py
+++ b/src/domain/expense/service.py
@@ -142,9 +142,9 @@ class ExpenseService(
                     func.date(Expense.transaction_date) <= end_date
                 )
 
-        if min_value is not None:
+        if max(0, min_value) is not None:
             statement = statement.where(Expense.amount >= min_value)
-        if max_value is not None:
+        if max(0, max_value) is not None:
             statement = statement.where(Expense.amount <= max_value)
 
         result = await self.db.execute(statement)

--- a/src/domain/expense/service.py
+++ b/src/domain/expense/service.py
@@ -1,21 +1,20 @@
-from src.models import Expense
 from datetime import date
 from decimal import Decimal
-from typing import Any, Optional
-from sqlalchemy import select, func
-from src.exceptions import EntityNotFoundException, DatabaseException
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import SQLAlchemyError
+
 from src.common.base_service import BaseService
+from src.domain.category.service import CategoryService
 from src.domain.expense.schemas import (
     ExpenseCreateSchema,
     ExpenseSchema,
     ExpenseUpdateSchema,
 )
-from src.domain.category.service import CategoryService
-
-from sqlalchemy import select
-from sqlalchemy.exc import SQLAlchemyError
-from uuid import UUID
-from typing import Any
+from src.exceptions import DatabaseException, EntityNotFoundException
+from src.models import Expense
 
 
 class ExpenseService(
@@ -64,7 +63,7 @@ class ExpenseService(
         ).items():
             # Ensure only category_id can be set to None, other fields will be ignored if None
             if key == "category_id" and value is None:
-                setattr(expense, "category_id", value)
+                expense.category_id = value
             elif value is not None:
                 setattr(expense, key, value)
 
@@ -116,26 +115,33 @@ class ExpenseService(
         return expense
 
     async def get_all(
-        self, 
+        self,
         user_id: UUID,
-        date_filter: Optional[date] = None,
-        start_date: Optional[date] = None,
-        end_date: Optional[date] = None,
-        min_value: Optional[Decimal] = None,
-        max_value: Optional[Decimal] = None
+        date_filter: date | None = None,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        min_value: Decimal | None = None,
+        max_value: Decimal | None = None,
     ) -> list[Expense]:
 
         statement = select(Expense).where(Expense.user_id == user_id)
-        
+
         if date_filter is not None:
-            statement = statement.where(func.date(Expense.transaction_date) == date_filter)
-            
-        # Filtri per range di date
-        if start_date is not None:
-            statement = statement.where(func.date(Expense.transaction_date) >= start_date)
-        if end_date is not None:
-            statement = statement.where(func.date(Expense.transaction_date) <= end_date)
-            
+            statement = statement.where(
+                func.date(Expense.transaction_date) == date_filter
+            )
+
+        else:
+            # Filtri per range di date
+            if start_date is not None:
+                statement = statement.where(
+                    func.date(Expense.transaction_date) >= start_date
+                )
+            if end_date is not None:
+                statement = statement.where(
+                    func.date(Expense.transaction_date) <= end_date
+                )
+
         if min_value is not None:
             statement = statement.where(Expense.amount >= min_value)
         if max_value is not None:

--- a/src/domain/expense/tests/test_expense_routes.py
+++ b/src/domain/expense/tests/test_expense_routes.py
@@ -1,7 +1,9 @@
-import pytest
+from datetime import UTC
 from decimal import Decimal
 
-from src.domain.expense.schemas import ExpenseUpdateSchema, ExpenseSchema
+import pytest
+
+from src.domain.expense.schemas import ExpenseSchema, ExpenseUpdateSchema
 
 
 class TestExpenseRoutes:
@@ -408,12 +410,11 @@ class TestExpenseRoutes:
         assert request_id is not None, "request_id should not be null"
         assert isinstance(request_id, str), "request_id should be a string (UUID)"
 
-    
     @pytest.mark.asyncio
     async def test_list_expenses_with_filters(
         self, authenticated_client, user, category_factory, expense_factory
     ):
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         category = await category_factory(user_id=user.uid)
 
@@ -421,28 +422,32 @@ class TestExpenseRoutes:
             user_id=user.uid,
             category_id=category.id,
             amount=Decimal("10.00"),
-            transaction_date=datetime(2023, 1, 1, tzinfo=timezone.utc)
+            transaction_date=datetime(2023, 1, 1, tzinfo=UTC),
         )
         await expense_factory(
             user_id=user.uid,
             category_id=category.id,
             amount=Decimal("50.00"),
-            transaction_date=datetime(2023, 1, 15, tzinfo=timezone.utc)
+            transaction_date=datetime(2023, 1, 15, tzinfo=UTC),
         )
         await expense_factory(
             user_id=user.uid,
             category_id=category.id,
             amount=Decimal("100.00"),
-            transaction_date=datetime(2023, 1, 31, tzinfo=timezone.utc)
+            transaction_date=datetime(2023, 1, 31, tzinfo=UTC),
         )
 
-        resp_value = await authenticated_client.get("/expenses/?min_value=20&max_value=80")
+        resp_value = await authenticated_client.get(
+            "/expenses/?min_value=20&max_value=80"
+        )
         assert resp_value.status_code == 200
         data_value = resp_value.json()
         assert len(data_value) == 1
         assert data_value[0]["amount"] == "50.00"
 
-        resp_range = await authenticated_client.get("/expenses/?start_date=2023-01-10&end_date=2023-01-20")
+        resp_range = await authenticated_client.get(
+            "/expenses/?start_date=2023-01-10&end_date=2023-01-20"
+        )
         assert resp_range.status_code == 200
         data_range = resp_range.json()
         assert len(data_range) == 1

--- a/src/domain/expense/tests/test_expense_routes.py
+++ b/src/domain/expense/tests/test_expense_routes.py
@@ -407,3 +407,49 @@ class TestExpenseRoutes:
         request_id = data["error"].get("request_id")
         assert request_id is not None, "request_id should not be null"
         assert isinstance(request_id, str), "request_id should be a string (UUID)"
+
+    
+    @pytest.mark.asyncio
+    async def test_list_expenses_with_filters(
+        self, authenticated_client, user, category_factory, expense_factory
+    ):
+        from datetime import datetime, timezone
+
+        category = await category_factory(user_id=user.uid)
+
+        await expense_factory(
+            user_id=user.uid,
+            category_id=category.id,
+            amount=Decimal("10.00"),
+            transaction_date=datetime(2023, 1, 1, tzinfo=timezone.utc)
+        )
+        await expense_factory(
+            user_id=user.uid,
+            category_id=category.id,
+            amount=Decimal("50.00"),
+            transaction_date=datetime(2023, 1, 15, tzinfo=timezone.utc)
+        )
+        await expense_factory(
+            user_id=user.uid,
+            category_id=category.id,
+            amount=Decimal("100.00"),
+            transaction_date=datetime(2023, 1, 31, tzinfo=timezone.utc)
+        )
+
+        resp_value = await authenticated_client.get("/expenses/?min_value=20&max_value=80")
+        assert resp_value.status_code == 200
+        data_value = resp_value.json()
+        assert len(data_value) == 1
+        assert data_value[0]["amount"] == "50.00"
+
+        resp_range = await authenticated_client.get("/expenses/?start_date=2023-01-10&end_date=2023-01-20")
+        assert resp_range.status_code == 200
+        data_range = resp_range.json()
+        assert len(data_range) == 1
+        assert data_range[0]["amount"] == "50.00"
+
+        resp_exact = await authenticated_client.get("/expenses/?date=2023-01-31")
+        assert resp_exact.status_code == 200
+        data_exact = resp_exact.json()
+        assert len(data_exact) == 1
+        assert data_exact[0]["amount"] == "100.00"


### PR DESCRIPTION
# Fixes #62

## Purpose
To allow the frontend to filter expenses by date and amount. This prevents fetching the entire expense history at once and makes it possible to retrieve data for specific months, date ranges, or value thresholds.

## Changes
- Added optional query parameters (`date`, `start_date`, `end_date`, `min_value`, `max_value`) to the `GET /expenses/` endpoint in `routes.py`.
- Updated the `get_all` method in `ExpenseService` to dynamically apply SQLAlchemy filters if the query parameters are provided.
- Added a new test `test_list_expenses_with_filters` in `test_expense_routes.py` to verify that the filtering logic works correctly.

## How to Test
1. Run the test suite: `pytest src/domain/expense/tests/test_expense_routes.py` to verify the new filter logic passes.
2. Run the application locally and navigate to the Swagger UI (`/docs`). Test the `GET /expenses/` endpoint by entering different combinations of dates and min/max values to ensure the returned list is filtered accordingly.

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expense listing now supports filtering by exact date, date range (start/end), and amount range (min/max) for more precise searches.

* **Tests**
  * Added end-to-end tests that seed sample expenses and verify filtering by amount range, date range, and exact date returns the correct single matching result and amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->