### PR TITLE
Refactor budget factory to use provided name or generate a fake one; …

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -362,12 +362,11 @@ async def budget_factory(db_session):
         category_id=None,
         amount_limit=None,
         month_year=None,
-        note=None,
         name=None,
     ):
         budget = Budget(
             user_id=user_id,
-            name=fake.name(),
+            name=name or fake.name(),
             category_id=category_id,
             amount_limit=amount_limit
             or Decimal(fake.pydecimal(left_digits=3, right_digits=2, positive=True)),

--- a/src/domain/budget/tests/test_budget_routes.py
+++ b/src/domain/budget/tests/test_budget_routes.py
@@ -4,6 +4,7 @@ import pytest
 import pytest_asyncio
 
 from src.domain.budget.schemas import BudgetSchema, BudgetUpdateSchema
+from src.domain.category.service import CategoryService
 
 BUDGET_BASE_PATH = "/budgets"
 
@@ -172,7 +173,6 @@ class TestBudgetRoutes:
     async def test_update_budget_invalid_user_id(
         self,
         create_budget_request,
-        authenticated_client,
         authenticated_client_factory,
         user_factory,
     ):
@@ -250,3 +250,21 @@ class TestBudgetRoutes:
         response = await authenticated_client.delete(f"{BUDGET_BASE_PATH}/{budget_id}")
 
         assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_after_deleted_category_category_id_is_none(
+        self, db_session, user, create_budget_request, authenticated_client
+    ):
+        created = await create_budget_request()
+        budget = BudgetSchema.model_validate(created.json())
+
+        await CategoryService(db_session).delete(
+            object_id=budget.category_id, user_id=user.uid
+        )
+
+        updated = await authenticated_client.get(f"{BUDGET_BASE_PATH}/{budget.id}")
+        budget = BudgetSchema.model_validate(updated.json())
+        assert updated.status_code == 200
+
+        assert budget.category_id is None
+        assert budget.name == updated.json()["name"]

--- a/src/domain/budget/tests/test_budget_routes.py
+++ b/src/domain/budget/tests/test_budget_routes.py
@@ -256,13 +256,13 @@ class TestBudgetRoutes:
         self, db_session, user, create_budget_request, authenticated_client
     ):
         created = await create_budget_request()
-        budget = BudgetSchema.model_validate(created.json())
+        pre_updated = BudgetSchema.model_validate(created.json())
 
         await CategoryService(db_session).delete(
-            object_id=budget.category_id, user_id=user.uid
+            object_id=pre_updated.category_id, user_id=user.uid
         )
 
-        updated = await authenticated_client.get(f"{BUDGET_BASE_PATH}/{budget.id}")
+        updated = await authenticated_client.get(f"{BUDGET_BASE_PATH}/{pre_updated.id}")
         budget = BudgetSchema.model_validate(updated.json())
         assert updated.status_code == 200
 

--- a/src/domain/budget/tests/test_budget_service.py
+++ b/src/domain/budget/tests/test_budget_service.py
@@ -1,13 +1,13 @@
+import copy
+from datetime import timedelta
+
 import pytest
 import pytest_asyncio
-import copy
 
-from src.domain.budget.service import BudgetService
-from src.exceptions import EntityNotFoundException
-
-from src.domain.category.service import CategoryService
 from src.domain.budget.schemas import BudgetUpdateSchema
-from datetime import timedelta
+from src.domain.budget.service import BudgetService
+from src.domain.category.service import CategoryService
+from src.exceptions import EntityNotFoundException
 
 
 @pytest_asyncio.fixture
@@ -220,3 +220,27 @@ class TestBudgetService:
             await service.update(
                 object_id=budget.id, data=update_data, user_id=user.uid
             )
+
+    @pytest.mark.asyncio
+    async def test_deleted_category_set_category_id_null(
+        self, db_session, budget_factory, user, category
+    ):
+        budget1 = await budget_factory(
+            user_id=user.uid, name=None, category_id=category.id
+        )
+        budget2 = await budget_factory(
+            user_id=user.uid, name=None, category_id=category.id
+        )
+        budget3 = await budget_factory(
+            user_id=user.uid, name=None, category_id=category.id
+        )
+
+        loop = budget1, budget2, budget3
+
+        await CategoryService(db_session).delete(
+            object_id=category.id, user_id=user.uid
+        )
+
+        for budget in loop:
+            await db_session.refresh(budget)
+            assert budget.category_id is None


### PR DESCRIPTION
…add tests for category deletion affecting budget category_id

# Fixes #
tests for deletion category 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Budgets now correctly retain records with cleared category references when their category is deleted.

* **Tests**
  * Added coverage verifying budgets' category references become null after category deletion.
  * Improved test fixtures and import organization for more reliable, maintainable tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->